### PR TITLE
Allow setting custom DOCDIR

### DIFF
--- a/qt-fsarchiver-terminal/qt-fsarchiver-terminal.pro
+++ b/qt-fsarchiver-terminal/qt-fsarchiver-terminal.pro
@@ -102,7 +102,11 @@ SOURCES += src/archinfo.c \
            src/thread_comp.c \
            src/writebuf.c
 # install
+ isEmpty(DOC_DIR) {
+   DOC_DIR = /usr/share/doc/qt-fsarchiver-terminal
+ }
+
  target.path = /usr/sbin
- doc.files = doc
- doc.path = /usr/share/doc/qt-fsarchiver-terminal/doc
+ doc.files = doc/*
+ doc.path = $$DOC_DIR
 INSTALLS = target doc


### PR DESCRIPTION
By setting DOC_DIR when invoking qmake you can now
set the target directory for the documentation files.